### PR TITLE
refactor(auth): allow auth cmd even if authrequired is false

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -26,11 +26,17 @@ type LoginInfo struct {
 type ValidateCallbackFunc func(username string, password string) (orgID string, intputID string, err error)
 
 var (
-	Authentication = &AuthenticationValidator{}
+	Authentication = &AuthenticationValidator{
+		handleFunctions: DefaultValidator,
+	}
 )
 
 type AuthenticationValidator struct {
 	handleFunctions ValidateCallbackFunc
+}
+
+func DefaultValidator(username string, password string) (orgID string, intputID string, err error) {
+	return "", "", nil
 }
 
 func (v *AuthenticationValidator) AddValidator(f ValidateCallbackFunc) {

--- a/server.go
+++ b/server.go
@@ -365,9 +365,6 @@ func (s *server) handleClient(client *client) {
 	// Extended feature advertisements
 	messageSize := fmt.Sprintf("250-SIZE %d\r\n", sc.MaxSize)
 	advertiseAuth := "250-AUTH LOGIN\r\n"
-	if !sc.AuthenticationRequired {
-		advertiseAuth = ""
-	}
 	pipelining := "250-PIPELINING\r\n"
 	advertiseTLS := "250-STARTTLS\r\n"
 	advertiseEnhancedStatusCodes := "250-ENHANCEDSTATUSCODES\r\n"
@@ -551,10 +548,6 @@ func (s *server) handleClient(client *client) {
 				break
 			}
 		case cmdAuth.match(cmd):
-			if !sc.AuthenticationRequired {
-				err = client.sendResponse(s.timeout.Load().(time.Duration), r.FailUnrecognizedCmd)
-				break
-			}
 			if loginInfo.status == true {
 				err = client.sendResponse(s.timeout.Load().(time.Duration), r.FailNoIdentityChangesPermitted)
 				break

--- a/tests/guerrilla_test.go
+++ b/tests/guerrilla_test.go
@@ -863,7 +863,7 @@ func TestHeloEhlo(t *testing.T) {
 				}
 			}
 
-			expected = fmt.Sprintf("250-%s Hello\r\n250-SIZE 100017\r\n250-PIPELINING\r\n250-STARTTLS\r\n250-ENHANCEDSTATUSCODES\r\n250 HELP\r\n", hostname)
+			expected = fmt.Sprintf("250-%s Hello\r\n250-SIZE 100017\r\n250-AUTH LOGIN\r\n250-PIPELINING\r\n250-STARTTLS\r\n250-ENHANCEDSTATUSCODES\r\n250 HELP\r\n", hostname)
 			if fullresp != expected {
 				t.Error("Server did not respond with [" + expected + "], it said [" + fullresp + "]")
 			}


### PR DESCRIPTION
## Why
In some scenario (sureview client), a client may choose to send a mail with and without auth cmd. To meet the requirement,  if the `AuthenticationRequired` of ServerConfig is `false`, the server still provide the AUTH cmd for clients.

## How
1. Add a default auth validator which always return `true`.
2. Allow auth method even if `AuthenticationRequired` is false.