### PR TITLE
Refactor(server): make auth-callback function more generic

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -23,7 +23,7 @@ type LoginInfo struct {
 	status   bool
 }
 
-type ValidateCallbackFunc func(username string, password string) (orgID string, intputID string, err error)
+type ValidateCallbackFunc func(username string, password string) (map[string]interface{}, error)
 
 var (
 	Authentication = &AuthenticationValidator{
@@ -35,14 +35,14 @@ type AuthenticationValidator struct {
 	handleFunctions ValidateCallbackFunc
 }
 
-func DefaultValidator(username string, password string) (orgID string, intputID string, err error) {
-	return "", "", nil
+func DefaultValidator(username, password string) (map[string]interface{},error) {
+	return nil, nil
 }
 
 func (v *AuthenticationValidator) AddValidator(f ValidateCallbackFunc) {
 	v.handleFunctions = f
 }
 
-func (v *AuthenticationValidator) Validate(a *LoginInfo) (string, string, error) {
+func (v *AuthenticationValidator) Validate(a *LoginInfo) (map[string]interface{}, error) {
 	return v.handleFunctions(a.username, a.password)
 }

--- a/server.go
+++ b/server.go
@@ -695,14 +695,17 @@ func (s *server) handleAuth(client *client, r response.Responses) (loginInfo Log
 	}
 	loginInfo.password = string(bsPassword)
 	// Validate the username and password from validate function
-	orgID, inputID, err := Authentication.Validate(&loginInfo)
+	values, err := Authentication.Validate(&loginInfo)
 	if err != nil {
 		err = client.sendResponse(s.timeout.Load().(time.Duration), r.FailAuthNotAccepted)
 		return LoginInfo{}, err
 	}
+	for key, v := range values {
+		if key != "" && v != nil {
+			client.Values[key] = v
+		}
+	}
 	loginInfo.status = true
-	client.Values["orgID"] = orgID
-	client.Values["inputID"] = inputID
 	err = client.sendResponse(s.timeout.Load().(time.Duration), r.SuccessAuthentication)
 	if err != nil {
 		return LoginInfo{}, err
@@ -739,14 +742,19 @@ func (s *server) handleAuthWithUsername(
 	}
 	loginInfo.password = string(bsPassword)
 	// Validate the username and password from validate function
-	orgID, inputID, err := Authentication.Validate(&loginInfo)
+	values, err := Authentication.Validate(&loginInfo)
 	if err != nil {
 		err = client.sendResponse(s.timeout.Load().(time.Duration), r.FailAuthNotAccepted)
 		return LoginInfo{}, err
 	}
+
+	for key, v := range values {
+		if key != "" && v != nil {
+			client.Values[key] = v
+		}
+	}
 	loginInfo.status = true
-	client.Values["orgID"] = orgID
-	client.Values["inputID"] = inputID
+
 	err = client.sendResponse(s.timeout.Load().(time.Duration), r.SuccessAuthentication)
 	if err != nil {
 		return LoginInfo{}, err

--- a/server_test.go
+++ b/server_test.go
@@ -614,11 +614,11 @@ func TestAuthenticationSuccess(t *testing.T) {
 			mainlog.WithError(logOpenError).Errorf("Failed creating a logger for mock conn [%s]", sc.ListenInterface)
 		}
 		conn, server := getMockServerConn(sc, t)
-		Authentication.AddValidator(func(u string, p string) (string, string, error) {
+		Authentication.AddValidator(func(u string, p string) (map[string]interface{}, error) {
 			if u == "helloworld" && p == "helloworld" {
-				return "000000", "aaaaaaaa", nil
+				return map[string]interface{}{"orgID": "000000", "inputID": "aaaaaaaa"}, nil
 			}
-			return "", "", errors.New("fail to perform authentication")
+			return nil, errors.New("fail to perform authentication")
 		})
 		// call the serve.handleClient() func in a goroutine.
 		client := NewClient(conn.Server, 1, mainlog, mail.NewPool(5))
@@ -696,8 +696,8 @@ func TestAuthenticationFailed(t *testing.T) {
 		mainlog.WithError(logOpenError).Errorf("Failed creating a logger for mock conn [%s]", sc.ListenInterface)
 	}
 	conn, server := getMockServerConn(sc, t)
-	Authentication.AddValidator(func(string, string) (string, string, error) {
-		return "", "", errors.New("fail to perform authentication")
+	Authentication.AddValidator(func(string, string) (map[string]interface{}, error) {
+		return nil, errors.New("fail to perform authentication")
 	})
 	// call the serve.handleClient() func in a goroutine.
 	client := NewClient(conn.Server, 1, mainlog, mail.NewPool(5))
@@ -754,11 +754,11 @@ func TestAuthenticationWithUsername(t *testing.T) {
 		mainlog.WithError(logOpenError).Errorf("Failed creating a logger for mock conn [%s]", sc.ListenInterface)
 	}
 	conn, server := getMockServerConn(sc, t)
-	Authentication.AddValidator(func(u string, p string) (string, string, error) {
+	Authentication.AddValidator(func(u string, p string) (map[string]interface{}, error) {
 		if u == "helloworld" && p == "helloworld" {
-			return "000000", "aaaaaaaa", nil
+			return map[string]interface{}{"orgID": "000000", "inputID": "aaaaaaaa"}, nil
 		}
-		return "", "", errors.New("fail to perform authentication")
+		return nil, errors.New("fail to perform authentication")
 	})
 	// call the serve.handleClient() func in a goroutine.
 	client := NewClient(conn.Server, 1, mainlog, mail.NewPool(5))
@@ -818,7 +818,9 @@ func TestCmdBeforeAuthentication(t *testing.T) {
 		mainlog.WithError(logOpenError).Errorf("Failed creating a logger for mock conn [%s]", sc.ListenInterface)
 	}
 	conn, server := getMockServerConn(sc, t)
-	Authentication.AddValidator(func(string, string) (string, string, error) { return "", "", nil })
+	Authentication.AddValidator(func(u string, p string) (map[string]interface{}, error) {
+		return nil, errors.New("fail to perform authentication")
+	})
 	// call the serve.handleClient() func in a goroutine.
 	client := NewClient(conn.Server, 1, mainlog, mail.NewPool(5))
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Why
The old auth callback function is only for Lantern events which needs orgID and inputID, so we need a more generic auth callback that can be used to other projects.

## How
Return `SetValuesFunc` after validating user's name and password, so we can insert required values to `client.Values` which across all processors during processing emails.